### PR TITLE
Bump upload-artifact to v4.6.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
       run: |
         aws s3 cp ./gosec-results.json s3://${{ inputs.s3-bucket }}/${{ inputs.s3-path }}/${{ steps.date-partition.outputs.DATE_PARTITION }}/$GITHUB_REPOSITORY.json
     - name: Upload scan results artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # pin@v4.6.0
       with:
         name: gosec-results
         path: gosec-results.json


### PR DESCRIPTION
* Bump upload-artifact to v4.6.0 because v3 is deprecated and causing the action to fail