### PR TITLE
[SEC-6431] bumped gosec action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Checkout Source
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
     - name: Run Gosec Security Scanner
-      uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # pin@v2.20.0
+      uses: securego/gosec@e0cca6fe95306b7e7790d6f1bf6a7bec6d622459 # pin@v2.22.0
       with:
         args: ${{ inputs.gosec-args }}
     - name: Configure AWS Credentials


### PR DESCRIPTION
This should pick up the [go version detection](https://github.com/securego/gosec?tab=readme-ov-file#go-version) to avoid the version mismatch issue described [here](https://launchdarkly.atlassian.net/browse/SEC-6431?focusedCommentId=306318).